### PR TITLE
fixed the path to the executable `fift`

### DIFF
--- a/tsa-core/src/main/kotlin/org/usvm/machine/TvmAnalyzer.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/TvmAnalyzer.kt
@@ -269,7 +269,9 @@ class FiftAnalyzer(
 
     fun compileFiftToBoc(fiftPath: Path, bocFilePath: Path) {
         val fiftStdin = "\"$fiftPath\" include boc>B \"$bocFilePath\" B>file"
-        performFiftCommand("fift", bocFilePath, fiftStdin)
+
+        val fiftCommand = "$fiftExecutablePath"
+        performFiftCommand(fiftCommand, bocFilePath, fiftStdin)
     }
 
     /**


### PR DESCRIPTION
For my purposes, I had to rename the executable file `fift`. It turned out that in one place, a value not from the variable was being used :(