### PR TITLE
TLb memory optimized loading

### DIFF
--- a/tsa-core/src/main/kotlin/org/usvm/machine/TvmContext.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/TvmContext.kt
@@ -1,5 +1,6 @@
 package org.usvm.machine
 
+import io.ksmt.KAst
 import io.ksmt.KContext
 import io.ksmt.expr.KBitVecValue
 import io.ksmt.expr.KBvLogicalShiftRightExpr
@@ -344,3 +345,6 @@ class TvmContext(
         ctx: KContext,
     ) : KBvCustomSizeSort(ctx, INT_EXT256_BITS)
 }
+
+val KAst.tctx
+    get() = ctx as TvmContext

--- a/tsa-core/src/main/kotlin/org/usvm/machine/fields/TvmCellDataFieldManager.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/fields/TvmCellDataFieldManager.kt
@@ -18,7 +18,7 @@ import org.usvm.machine.types.TvmAddressToLabelMapper
 import org.usvm.machine.types.TvmCellType
 import org.usvm.machine.types.TvmType
 import org.usvm.memory.UWritableMemory
-import org.usvm.utils.extractAddresses
+import org.usvm.utils.flattenReferenceIte
 
 class TvmCellDataFieldManager(
     private val ctx: TvmContext,
@@ -89,7 +89,7 @@ class TvmCellDataFieldManager(
         cellRef: UHeapRef,
     ): UExpr<TvmContext.TvmCellDataSort>? =
         with(ctx) {
-            val staticRefs = extractAddresses(cellRef, extractAllocated = false, extractStatic = true)
+            val staticRefs = flattenReferenceIte(cellRef, extractAllocated = false, extractStatic = true)
 
             val newRefs = staticRefs.map { it.second }.filter { it.address !in addressesWithAssertedCellData }
             addressesWithAssertedCellData = addressesWithAssertedCellData.addAll(newRefs.map { it.address })
@@ -112,7 +112,7 @@ class TvmCellDataFieldManager(
         state: TvmState,
         cellRef: UHeapRef,
     ) = with(ctx) {
-        val staticRefs = extractAddresses(cellRef, extractAllocated = false, extractStatic = true)
+        val staticRefs = flattenReferenceIte(cellRef, extractAllocated = false, extractStatic = true)
         addressesWithRequestedCellDataField =
             addressesWithRequestedCellDataField.addAll(staticRefs.map { it.second.address })
 

--- a/tsa-core/src/main/kotlin/org/usvm/machine/fields/TvmCellDataLengthFieldManager.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/fields/TvmCellDataLengthFieldManager.kt
@@ -17,7 +17,7 @@ import org.usvm.machine.types.TvmSliceType
 import org.usvm.machine.types.TvmType
 import org.usvm.memory.UWritableMemory
 import org.usvm.sizeSort
-import org.usvm.utils.extractAddresses
+import org.usvm.utils.flattenReferenceIte
 import org.usvm.utils.intValueOrNull
 import org.usvm.utils.splitAndRead
 
@@ -98,7 +98,7 @@ class TvmCellDataLengthFieldManager(
         ctx: TvmContext,
         cellRef: UHeapRef,
     ): Int? {
-        val refs = ctx.extractAddresses(cellRef, extractStatic = true, extractAllocated = true)
+        val refs = ctx.flattenReferenceIte(cellRef, extractStatic = true, extractAllocated = true)
         return refs.maxOf {
             builderLengthUpperBoundTracker.builderRefToLengthUpperBound[it.second]
                 ?: return null
@@ -134,7 +134,7 @@ class TvmCellDataLengthFieldManager(
         to: UConcreteHeapRef,
     ) = with(state.ctx) {
         val value = readCellDataLength(state, from)
-        val fromRefs = extractAddresses(from, extractAllocated = true, extractStatic = true).map { it.second }
+        val fromRefs = flattenReferenceIte(from, extractAllocated = true, extractStatic = true).map { it.second }
         val upperBound =
             run {
                 fromRefs.maxOf {

--- a/tsa-core/src/main/kotlin/org/usvm/machine/interpreter/TvmArtificialInstInterpreter.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/interpreter/TvmArtificialInstInterpreter.kt
@@ -391,9 +391,16 @@ class TvmArtificialInstInterpreter(
                         getContractInfoParamOf(ADDRESS_PARAMETER_IDX, sender).cellValue ?: error("no destination :(")
                     }
                 // TODO fill the ihrFee, msgValue, ... with reasonable values
+                val bouncedFlags =
+                    RecvInternalInput.Flags(
+                        intMsgInfo = 0.toBv257(),
+                        ihrDisabled = 1.toBv257(),
+                        bounce = 0.toBv257(),
+                        bounced = 1.toBv257(),
+                    )
                 val content =
                     RecvInternalInput.MessageContent(
-                        flags = 0b0101.toBv257(),
+                        flags = bouncedFlags,
                         srcAddressSlice = oldMessage.destAddrSlice,
                         dstAddressSlice = scope.calcOnState { allocSliceFromCell(destinationCell) },
                         msgValue = zeroValue,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/interpreter/TvmInterpreter.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/interpreter/TvmInterpreter.kt
@@ -630,7 +630,7 @@ class TvmInterpreter(
     override fun step(state: TvmState): StepResult<TvmState> {
         val stmt = state.lastStmt
         logger.debug("Current contract: {}", state.currentContract)
-        logger.debug("Step: {}", stmt)
+        logger.debug("State id: {}, Step: {}", state.id, stmt)
 
         val initialGasUsage = state.gasUsageHistory
         val globalStructuralConstraintsHolder = state.globalStructuralConstraintsHolder

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeRead.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeRead.kt
@@ -1,15 +1,62 @@
 package org.usvm.machine.types
 
+import io.ksmt.expr.KInterpretedValue
 import io.ksmt.sort.KBvSort
+import kotlinx.collections.immutable.PersistentList
 import org.ton.Endian
+import org.ton.FixedSizeDataLabel
+import org.ton.TlbAddressByRef
+import org.ton.TlbBasicMsgAddrLabel
+import org.ton.TlbBitArrayByRef
+import org.ton.TlbBitArrayOfConcreteSize
+import org.ton.TlbBuiltinLabel
+import org.ton.TlbCoinsLabel
+import org.ton.TlbCompositeLabel
+import org.ton.TlbIntegerLabelOfConcreteSize
+import org.ton.TlbIntegerLabelOfSymbolicSize
+import org.ton.TlbMaybeRefLabel
+import org.ton.TlbStructure.KnownTypePrefix
+import org.ton.TlbStructure.SwitchPrefix
 import org.usvm.UAddressSort
 import org.usvm.UBoolExpr
 import org.usvm.UBoolSort
 import org.usvm.UExpr
+import org.usvm.UHeapRef
+import org.usvm.api.readField
 import org.usvm.machine.TvmContext
 import org.usvm.machine.TvmSizeSort
+import org.usvm.machine.intValue
+import org.usvm.machine.state.TvmState
+import org.usvm.machine.state.allocSliceFromData
+import org.usvm.machine.state.getSliceRemainingBitsCount
+import org.usvm.machine.tctx
+import org.usvm.machine.types.memory.ConcreteSizeBlockField
+import org.usvm.machine.types.memory.SliceRefField
+import org.usvm.machine.types.memory.SymbolicSizeBlockField
+import org.usvm.machine.types.memory.extractInt
+import org.usvm.machine.types.memory.generateGuardForSwitch
+import org.usvm.machine.types.memory.readConcreteBv
+import org.usvm.mkSizeExpr
+import kotlin.math.min
 
-sealed interface TvmCellDataTypeRead<ReadResult : TvmCellDataTypeReadValue>
+sealed interface TvmCellDataTypeRead<ReadResult> {
+    fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): ReadResult?
+
+    fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): ReadResult?
+
+    fun createLeftBitsDataLoad(leftBits: UExpr<TvmSizeSort>): TvmCellDataTypeRead<ReadResult>? = null
+}
 
 sealed interface SizedCellDataTypeRead {
     val sizeBits: UExpr<TvmSizeSort>
@@ -20,7 +67,44 @@ data class TvmCellDataIntegerRead(
     val isSigned: Boolean,
     val endian: Endian,
 ) : TvmCellDataTypeRead<UExprReadResult<TvmContext.TvmInt257Sort>>,
-    SizedCellDataTypeRead
+    SizedCellDataTypeRead {
+    override fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): UExprReadResult<TvmContext.TvmInt257Sort> {
+        val intExpr = extractInt(offset, sizeBits, data, isSigned)
+        return UExprReadResult(intExpr)
+    }
+
+    override fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): UExprReadResult<TvmContext.TvmInt257Sort>? =
+        with(state.ctx) {
+            if (label !is TlbIntegerLabelOfConcreteSize) {
+                return null
+            }
+
+            // no checks for sizeBits are made: they should be done before this call
+
+            val field = ConcreteSizeBlockField(label.concreteSize, curStructure.id, path)
+            val value = state.memory.readField(address, field, field.getSort(this))
+
+            val result =
+                if (isSigned) {
+                    value.signedExtendToInteger()
+                } else {
+                    value.unsignedExtendToInteger()
+                }
+
+            UExprReadResult(result)
+        }
+}
 
 class TvmCellMaybeConstructorBitRead(
     val ctx: TvmContext,
@@ -28,24 +112,284 @@ class TvmCellMaybeConstructorBitRead(
     SizedCellDataTypeRead {
     override val sizeBits: UExpr<TvmSizeSort>
         get() = ctx.oneSizeExpr
+
+    override fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): UExprReadResult<UBoolSort> =
+        with(offset.tctx) {
+            val bit = extractInt(offset, oneSizeExpr, data, isSigned = false)
+            val boolExpr =
+                mkIte(
+                    bit eq zeroValue,
+                    trueBranch = { falseExpr },
+                    falseBranch = { trueExpr },
+                )
+            UExprReadResult(boolExpr)
+        }
+
+    override fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): UExprReadResult<UBoolSort>? =
+        with(state.ctx) {
+            if (label !is TlbMaybeRefLabel) {
+                return null
+            }
+
+            val newPath = path.add(curStructure.id)
+
+            val switchStruct =
+                label.internalStructure as? SwitchPrefix
+                    ?: error("structure of TlbMaybeRefLabel must be switch")
+
+            val possibleVariants =
+                state.dataCellInfoStorage.mapper.calculatedTlbLabelInfo.getPossibleSwitchVariants(
+                    switchStruct,
+                    leftTlbDepth,
+                )
+            val trueVariant = possibleVariants.indexOfFirst { it.key == "1" }
+
+            if (trueVariant == -1) {
+                return@with UExprReadResult(falseExpr)
+            }
+
+            val expr = generateGuardForSwitch(switchStruct, trueVariant, possibleVariants, state, address, newPath)
+            UExprReadResult(expr)
+        }
 }
 
 // As a read result expects address length + slice with the address
 class TvmCellDataMsgAddrRead(
     val ctx: TvmContext,
-) : TvmCellDataTypeRead<UExprPairReadResult<TvmSizeSort, UAddressSort>>
+) : TvmCellDataTypeRead<UExprPairReadResult<TvmSizeSort, UAddressSort>> {
+    override fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): UExprPairReadResult<TvmSizeSort, UAddressSort>? =
+        with(offset.tctx) {
+            val concreteOffset = if (offset is KInterpretedValue) offset.intValue() else null
+            val twoDataBits =
+                if (concreteOffset != null) {
+                    data.substring(concreteOffset, min(concreteOffset + 2, data.length))
+                } else {
+                    null
+                }
+            if (twoDataBits == "00") {
+                UExprPairReadResult(twoSizeExpr, state.allocSliceFromData(mkBv(0, sizeBits = 2u)))
+            } else {
+                null
+            }
+        }
+
+    override fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): UExprPairReadResult<TvmSizeSort, UAddressSort>? =
+        when (label) {
+            is TlbAddressByRef -> {
+                val field = SliceRefField(curStructure.id, path)
+                val value = state.memory.readField(address, field, field.getSort(ctx))
+                val length = state.getSliceRemainingBitsCount(value)
+                UExprPairReadResult(length, value)
+            }
+
+            is TlbBasicMsgAddrLabel ->
+                with(state.ctx) {
+                    val struct =
+                        (label as TlbCompositeLabel).internalStructure as? SwitchPrefix
+                            ?: error("structure of TlbFullMsgAddrLabel must be switch")
+
+                    if (struct.variants.size > 1) {
+                        TODO()
+                    }
+
+                    val variant = struct.variants.single()
+
+                    val rest =
+                        variant.struct as? KnownTypePrefix
+                            ?: error("Unexpected structure: ${variant.struct}")
+                    val restLabel =
+                        rest.typeLabel as? FixedSizeDataLabel
+                            ?: error("Unexpected label: ${rest.typeLabel}")
+                    val restField = ConcreteSizeBlockField(restLabel.concreteSize, rest.id, path.add(curStructure.id))
+                    val restValue = state.memory.readField(address, restField, restField.getSort(this))
+
+                    val prefix = mkBv(variant.key, variant.key.length.toUInt())
+
+                    val content = mkBvConcatExpr(prefix, restValue)
+
+                    val value = state.allocSliceFromData(content)
+                    val length = mkSizeExpr(TvmContext.stdMsgAddrSize)
+                    UExprPairReadResult(length, value)
+                }
+
+            else -> {
+                null
+            }
+        }
+}
 
 data class TvmCellDataBitArrayRead(
     override val sizeBits: UExpr<TvmSizeSort>,
 ) : TvmCellDataTypeRead<UExprReadResult<UAddressSort>>,
-    SizedCellDataTypeRead
+    SizedCellDataTypeRead {
+    override fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): UExprReadResult<UAddressSort>? =
+        with(offset.tctx) {
+            if (offset is KInterpretedValue) {
+                val bits =
+                    readConcreteBv(state.ctx, offset.intValue(), data, sizeBits)
+                        ?: return null
+                val slice = state.allocSliceFromData(bits)
+                UExprReadResult(slice)
+            } else {
+                null
+            }
+        }
+
+    override fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): UExprReadResult<UAddressSort>? =
+        with(state.ctx) {
+            when (label) {
+                is TlbBitArrayOfConcreteSize -> {
+                    val field = ConcreteSizeBlockField(label.concreteSize, curStructure.id, path)
+                    val fieldValue = state.memory.readField(address, field, field.getSort(this))
+                    UExprReadResult(state.allocSliceFromData(fieldValue))
+                }
+
+                is TlbBitArrayByRef -> {
+                    val field = SliceRefField(curStructure.id, path)
+                    val value = state.memory.readField(address, field, field.getSort(this))
+                    UExprReadResult(value)
+                }
+
+                is TlbAddressByRef -> {
+                    val field = SliceRefField(curStructure.id, path)
+                    val value = state.memory.readField(address, field, field.getSort(this))
+                    UExprReadResult(value)
+                }
+
+                is TlbBasicMsgAddrLabel -> {
+                    val struct =
+                        (label as TlbCompositeLabel).internalStructure as? SwitchPrefix
+                            ?: error("structure of TlbFullMsgAddrLabel must be switch")
+
+                    if (struct.variants.size > 1) {
+                        TODO()
+                    }
+
+                    val variant = struct.variants.single()
+
+                    val rest =
+                        variant.struct as? KnownTypePrefix
+                            ?: error("Unexpected structure: ${variant.struct}")
+                    val restLabel =
+                        rest.typeLabel as? FixedSizeDataLabel
+                            ?: error("Unexpected label: ${rest.typeLabel}")
+                    val restField = ConcreteSizeBlockField(restLabel.concreteSize, rest.id, path.add(curStructure.id))
+                    val restValue = state.memory.readField(address, restField, restField.getSort(this))
+
+                    val prefix = mkBv(variant.key, variant.key.length.toUInt())
+
+                    val content = mkBvConcatExpr(prefix, restValue)
+
+                    val value = state.allocSliceFromData(content)
+                    UExprReadResult(value)
+                }
+
+                else -> {
+                    null
+                }
+            }
+        }
+
+    override fun createLeftBitsDataLoad(leftBits: UExpr<TvmSizeSort>): TvmCellDataBitArrayRead =
+        TvmCellDataBitArrayRead(leftBits)
+}
 
 // As a read result expects bitvector of size 4 (coin prefix) + coin value as int257
 class TvmCellDataCoinsRead(
     val ctx: TvmContext,
-) : TvmCellDataTypeRead<UExprPairReadResult<KBvSort, TvmContext.TvmInt257Sort>>
+) : TvmCellDataTypeRead<UExprPairReadResult<KBvSort, TvmContext.TvmInt257Sort>> {
+    override fun readFromConstant(
+        state: TvmState,
+        offset: UExpr<TvmSizeSort>,
+        data: String,
+    ): UExprPairReadResult<KBvSort, TvmContext.TvmInt257Sort>? =
+        with(offset.tctx) {
+            val concreteOffset = if (offset is KInterpretedValue) offset.intValue() else null
+            val fourDataBits =
+                if (concreteOffset != null) {
+                    data.substring(concreteOffset, min(concreteOffset + 4, data.length))
+                } else {
+                    null
+                }
 
-fun <ReadResult : TvmCellDataTypeReadValue> TvmCellDataTypeRead<ReadResult>.isEmptyRead(ctx: TvmContext): UBoolExpr =
+            if (fourDataBits == "0000") {
+                UExprPairReadResult(mkBv(0, mkBvSort(4u)), zeroValue)
+            } else {
+                null
+            }
+        }
+
+    override fun extractTlbValueIfPossible(
+        curStructure: KnownTypePrefix,
+        label: TlbBuiltinLabel,
+        address: UHeapRef,
+        path: PersistentList<Int>,
+        state: TvmState,
+        leftTlbDepth: Int,
+    ): UExprPairReadResult<KBvSort, TvmContext.TvmInt257Sort>? =
+        with(state.ctx) {
+            if (label !is TlbCoinsLabel) {
+                return null
+            }
+
+            val newPath = path.add(curStructure.id)
+
+            val lengthStruct = label.internalStructure as KnownTypePrefix
+            check(lengthStruct.typeLabel is TlbIntegerLabelOfConcreteSize)
+
+            val gramsStruct = lengthStruct.rest as KnownTypePrefix
+            check(gramsStruct.typeLabel is TlbIntegerLabelOfSymbolicSize)
+
+            val gramsField = SymbolicSizeBlockField(gramsStruct.typeLabel.lengthUpperBound, gramsStruct.id, newPath)
+            val gramsValue =
+                state.memory
+                    .readField(
+                        address,
+                        gramsField,
+                        gramsField.getSort(this),
+                    ).unsignedExtendToInteger()
+
+            val lengthField = ConcreteSizeBlockField(lengthStruct.typeLabel.concreteSize, lengthStruct.id, newPath)
+            val lengthValue = state.memory.readField(address, lengthField, lengthField.getSort(this))
+
+            UExprPairReadResult(lengthValue, gramsValue)
+        }
+}
+
+fun <ReadResult> TvmCellDataTypeRead<ReadResult>.isEmptyRead(ctx: TvmContext): UBoolExpr =
     with(ctx) {
         when (this@isEmptyRead) {
             is SizedCellDataTypeRead -> sizeBits eq zeroSizeExpr

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeReadValue.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeReadValue.kt
@@ -27,6 +27,7 @@ fun <ReadResult : TvmCellDataTypeReadValue> mkIte(
         is UExprReadResult<*> -> {
             mkUExprIte<KSort>(ctx, condition, trueBranch.uncheckedCast(), falseBranch.uncheckedCast()).uncheckedCast()
         }
+
         is UExprPairReadResult<*, *> -> {
             mkUExprPairIte<KSort, KSort>(
                 ctx,
@@ -35,7 +36,6 @@ fun <ReadResult : TvmCellDataTypeReadValue> mkIte(
                 falseBranch.uncheckedCast(),
             ).uncheckedCast()
         }
-        else -> error("Unexpected value: $trueBranch")
     }
 
 fun <Sort : KSort> mkUExprIte(

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeReadValue.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmCellDataTypeReadValue.kt
@@ -17,7 +17,7 @@ class UExprPairReadResult<Sort1 : KSort, Sort2 : KSort>(
     val second: UExpr<Sort2>,
 ) : TvmCellDataTypeReadValue
 
-fun <ReadResult : TvmCellDataTypeReadValue> mkIte(
+fun <ReadResult> mkIte(
     ctx: TvmContext,
     condition: UBoolExpr,
     trueBranch: ReadResult,
@@ -36,6 +36,8 @@ fun <ReadResult : TvmCellDataTypeReadValue> mkIte(
                 falseBranch.uncheckedCast(),
             ).uncheckedCast()
         }
+
+        else -> error("...")
     }
 
 fun <Sort : KSort> mkUExprIte(

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellInfoStorage.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellInfoStorage.kt
@@ -12,7 +12,7 @@ import org.usvm.machine.state.TvmState
 import org.usvm.machine.types.dp.CalculatedTlbLabelInfo
 import org.usvm.mkSizeGeExpr
 import org.usvm.mkSizeLeExpr
-import org.usvm.utils.extractAddresses
+import org.usvm.utils.flattenReferenceIte
 
 class TvmDataCellInfoStorage private constructor(
     private val ctx: TvmContext,
@@ -23,7 +23,7 @@ class TvmDataCellInfoStorage private constructor(
         state: TvmState,
         ref: UHeapRef,
     ) = with(ctx) {
-        val staticAddresses = extractAddresses(ref).map { it.second }
+        val staticAddresses = flattenReferenceIte(ref).map { it.second }
 
         staticAddresses.forEach {
             if (!state.isTerminated) {
@@ -34,7 +34,7 @@ class TvmDataCellInfoStorage private constructor(
 
     fun getLabelForFreshSlice(cellRef: UHeapRef): Map<TvmParameterInfo.CellInfo, UBoolExpr> =
         with(ctx) {
-            val staticAddresses = extractAddresses(cellRef, extractAllocated = true)
+            val staticAddresses = flattenReferenceIte(cellRef, extractAllocated = true)
             val result = hashMapOf<TvmParameterInfo.CellInfo, UBoolExpr>()
 
             staticAddresses.forEach { (guard, ref) ->

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellLoadedTypeInfo.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellLoadedTypeInfo.kt
@@ -24,7 +24,7 @@ class TvmDataCellLoadedTypeInfo(
         val cellAddress: UConcreteHeapRef
     }
 
-    class LoadData<ReadResult : TvmCellDataTypeReadValue>(
+    class LoadData<ReadResult>(
         override val guard: UBoolExpr,
         override val cellAddress: UConcreteHeapRef,
         val type: TvmCellDataTypeRead<ReadResult>,
@@ -72,7 +72,7 @@ class TvmDataCellLoadedTypeInfo(
         referenceToActions = newMap
     }
 
-    fun <ReadResult : TvmCellDataTypeReadValue> loadData(
+    fun <ReadResult> loadData(
         state: TvmState,
         offset: UExpr<TvmSizeSort>,
         type: TvmCellDataTypeRead<ReadResult>,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
@@ -66,7 +66,7 @@ private fun <T> MutableMap<T, UBoolExpr>.addGuardedOutcome(
     this@addGuardedOutcome[key] = mkOr(oldGuard, guard, flat = false)
 }
 
-private fun <ReadResult : TvmCellDataTypeReadValue> MutableMap<
+private fun <ReadResult> MutableMap<
     MakeSliceTypeLoadOutcome,
     MutableMap<ReadResult?, UBoolExpr>,
 >.addGuardedTypeloadOutcome(
@@ -78,7 +78,7 @@ private fun <ReadResult : TvmCellDataTypeReadValue> MutableMap<
     innerMap.addGuardedOutcome(readValue, guard)
 }
 
-fun <ReadResult : TvmCellDataTypeReadValue> TvmStepScopeManager.makeSliceTypeLoad(
+fun <ReadResult> TvmStepScopeManager.makeSliceTypeLoad(
     oldSlice: UHeapRef,
     type: TvmCellDataTypeRead<ReadResult>,
     newSlice: UConcreteHeapRef,
@@ -185,7 +185,7 @@ fun <ReadResult : TvmCellDataTypeReadValue> TvmStepScopeManager.makeSliceTypeLoa
     )
 }
 
-private fun <ReadResult : TvmCellDataTypeReadValue> retryWithBitvectorRead(
+private fun <ReadResult> retryWithBitvectorRead(
     type: TvmCellDataIntegerRead,
     load: TvmDataCellLoadedTypeInfo.LoadData<ReadResult>,
     tlbStack: TlbStack,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
@@ -203,10 +203,7 @@ private fun <ReadResult : TvmCellDataTypeReadValue> retryWithBitvectorRead(
             load.offset,
             load.sliceAddress,
         )
-    val updatedLimitLoadData =
-        LimitedLoadData.fromLoadData(
-            updatedLoad,
-        )
+    val updatedLimitLoadData = LimitedLoadData.fromLoadData(updatedLoad)
     return tlbStack
         .step(state, updatedLimitLoadData)
         .map<TlbStack.GuardedResult<UExprReadResult<UAddressSort>>, TlbStack.GuardedResult<out ReadResult>> {

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmDataCellTypesHandlers.kt
@@ -191,7 +191,7 @@ private fun <ReadResult : TvmCellDataTypeReadValue> retryWithBitvectorRead(
     tlbStack: TlbStack,
     state: TvmState,
     stepResult: TlbStack.Error,
-    manager: TvmStepScopeManager,
+    scope: TvmStepScopeManager,
     context: TvmContext,
 ): List<TlbStack.GuardedResult<out ReadResult>> {
     val bitArrayReadType = TvmCellDataBitArrayRead(type.sizeBits)
@@ -220,12 +220,14 @@ private fun <ReadResult : TvmCellDataTypeReadValue> retryWithBitvectorRead(
             val expr =
                 value?.expr ?: return@map TlbStack.GuardedResult(guard, stepResultOrOldError, null)
             val result =
-                manager.slicePreloadInt(
+                scope.slicePreloadInt(
                     expr,
                     with(context) { type.sizeBits.zeroExtendToSort(state.ctx.int257sort) },
                     type.isSigned,
                 )
                     ?: return@map TlbStack.GuardedResult(guard, stepResultOrOldError, null)
+            // the `uncheckedCast` solution is fragile and will cause errors as more types will be used
+            // todo add runtime checks (additional fields must be added)
             TlbStack.GuardedResult(
                 guard,
                 newStepResult,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmTypeUtils.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/TvmTypeUtils.kt
@@ -50,7 +50,7 @@ fun TvmState.getPossibleTypes(ref: UConcreteHeapRef): Sequence<TvmType> {
     return typeSystem.findSubtypes(type)
 }
 
-fun <ReadResult : TvmCellDataTypeReadValue> TlbBuiltinLabel.accepts(
+fun <ReadResult> TlbBuiltinLabel.accepts(
     ctx: TvmContext,
     labelArgs: List<UExpr<TvmSizeSort>>,
     symbolicTypeRead: TvmCellDataTypeRead<ReadResult>,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
@@ -1,22 +1,10 @@
 package org.usvm.machine.types.memory
 
-import io.ksmt.expr.KInterpretedValue
 import io.ksmt.sort.KBvSort
-import io.ksmt.utils.uncheckedCast
 import kotlinx.collections.immutable.PersistentList
 import org.ton.FixedSizeDataLabel
-import org.ton.TlbAddressByRef
-import org.ton.TlbBasicMsgAddrLabel
-import org.ton.TlbBitArrayByRef
-import org.ton.TlbBitArrayOfConcreteSize
 import org.ton.TlbBuiltinLabel
-import org.ton.TlbCoinsLabel
-import org.ton.TlbCompositeLabel
-import org.ton.TlbIntegerLabelOfConcreteSize
-import org.ton.TlbIntegerLabelOfSymbolicSize
-import org.ton.TlbMaybeRefLabel
 import org.ton.TlbStructure.KnownTypePrefix
-import org.ton.TlbStructure.SwitchPrefix
 import org.usvm.UExpr
 import org.usvm.UHeapRef
 import org.usvm.UIntepretedValue
@@ -26,18 +14,8 @@ import org.usvm.machine.TvmContext.Companion.tctx
 import org.usvm.machine.TvmSizeSort
 import org.usvm.machine.intValue
 import org.usvm.machine.state.TvmState
-import org.usvm.machine.state.allocSliceFromData
 import org.usvm.machine.state.extractIntFromShiftedData
-import org.usvm.machine.state.getSliceRemainingBitsCount
-import org.usvm.machine.types.TvmCellDataBitArrayRead
-import org.usvm.machine.types.TvmCellDataCoinsRead
-import org.usvm.machine.types.TvmCellDataIntegerRead
-import org.usvm.machine.types.TvmCellDataMsgAddrRead
 import org.usvm.machine.types.TvmCellDataTypeRead
-import org.usvm.machine.types.TvmCellDataTypeReadValue
-import org.usvm.machine.types.TvmCellMaybeConstructorBitRead
-import org.usvm.machine.types.UExprPairReadResult
-import org.usvm.machine.types.UExprReadResult
 import org.usvm.mkSizeAddExpr
 import org.usvm.mkSizeExpr
 import org.usvm.mkSizeSubExpr
@@ -46,174 +24,14 @@ import kotlin.math.min
 /**
  * This function must be called only after checking that [TlbBuiltinLabel] accepts this [read].
  * */
-fun <ReadResult : TvmCellDataTypeReadValue> TlbBuiltinLabel.extractTlbValueIfPossible(
+fun <ReadResult> TlbBuiltinLabel.extractTlbValueIfPossible(
     curStructure: KnownTypePrefix,
     read: TvmCellDataTypeRead<ReadResult>,
     address: UHeapRef,
     path: PersistentList<Int>,
     state: TvmState,
     leftTlbDepth: Int,
-): ReadResult? =
-    with(state.ctx) {
-        check(curStructure.typeLabel == this@extractTlbValueIfPossible)
-        when (this@extractTlbValueIfPossible) {
-            is TlbCoinsLabel -> {
-                if (read !is TvmCellDataCoinsRead) {
-                    return null
-                }
-
-                val newPath = path.add(curStructure.id)
-
-                val lengthStruct = internalStructure as KnownTypePrefix
-                check(lengthStruct.typeLabel is TlbIntegerLabelOfConcreteSize)
-
-                val gramsStruct = lengthStruct.rest as KnownTypePrefix
-                check(gramsStruct.typeLabel is TlbIntegerLabelOfSymbolicSize)
-
-                val gramsField = SymbolicSizeBlockField(gramsStruct.typeLabel.lengthUpperBound, gramsStruct.id, newPath)
-                val gramsValue =
-                    state.memory
-                        .readField(
-                            address,
-                            gramsField,
-                            gramsField.getSort(this),
-                        ).unsignedExtendToInteger()
-
-                val lengthField = ConcreteSizeBlockField(lengthStruct.typeLabel.concreteSize, lengthStruct.id, newPath)
-                val lengthValue = state.memory.readField(address, lengthField, lengthField.getSort(this))
-
-                UExprPairReadResult(lengthValue, gramsValue).uncheckedCast<Any, ReadResult>()
-            }
-
-            is TlbIntegerLabelOfConcreteSize -> {
-                if (read !is TvmCellDataIntegerRead) {
-                    return null
-                }
-
-                // no checks for sizeBits are made: they should be done before this call
-
-                val field = ConcreteSizeBlockField(concreteSize, curStructure.id, path)
-                val value = state.memory.readField(address, field, field.getSort(this))
-
-                val result =
-                    if (read.isSigned) {
-                        value.signedExtendToInteger()
-                    } else {
-                        value.unsignedExtendToInteger()
-                    }
-
-                UExprReadResult(result).uncheckedCast<Any, ReadResult>()
-            }
-
-            is TlbBitArrayOfConcreteSize -> {
-                if (read !is TvmCellDataBitArrayRead) {
-                    return@with null
-                }
-
-                val field = ConcreteSizeBlockField(concreteSize, curStructure.id, path)
-                val fieldValue = state.memory.readField(address, field, field.getSort(this))
-
-                UExprReadResult(state.allocSliceFromData(fieldValue)).uncheckedCast<Any, ReadResult>()
-            }
-
-            is TlbBitArrayByRef -> {
-                if (read !is TvmCellDataBitArrayRead) {
-                    return@with null
-                }
-
-                val field = SliceRefField(curStructure.id, path)
-                val value = state.memory.readField(address, field, field.getSort(this))
-
-                UExprReadResult(value).uncheckedCast<Any, ReadResult>()
-            }
-
-            is TlbAddressByRef -> {
-                if (read !is TvmCellDataMsgAddrRead && read !is TvmCellDataBitArrayRead) {
-                    return@with null
-                }
-
-                val field = SliceRefField(curStructure.id, path)
-                val value = state.memory.readField(address, field, field.getSort(this))
-
-                val length = state.getSliceRemainingBitsCount(value)
-
-                when (read) {
-                    is TvmCellDataBitArrayRead -> UExprReadResult(value).uncheckedCast<Any, ReadResult>()
-                    is TvmCellDataMsgAddrRead -> UExprPairReadResult(length, value).uncheckedCast()
-                    else -> error("Unexpected read: $read")
-                }
-            }
-
-            is TlbBasicMsgAddrLabel -> {
-                if (read !is TvmCellDataMsgAddrRead && read !is TvmCellDataBitArrayRead) {
-                    return@with null
-                }
-
-                val struct =
-                    (this@extractTlbValueIfPossible as TlbCompositeLabel).internalStructure as? SwitchPrefix
-                        ?: error("structure of TlbFullMsgAddrLabel must be switch")
-
-                if (struct.variants.size > 1) {
-                    TODO()
-                }
-
-                val variant = struct.variants.single()
-
-                val rest =
-                    variant.struct as? KnownTypePrefix
-                        ?: error("Unexpected structure: ${variant.struct}")
-                val restLabel =
-                    rest.typeLabel as? FixedSizeDataLabel
-                        ?: error("Unexpected label: ${rest.typeLabel}")
-                val restField = ConcreteSizeBlockField(restLabel.concreteSize, rest.id, path.add(curStructure.id))
-                val restValue = state.memory.readField(address, restField, restField.getSort(this))
-
-                val prefix = mkBv(variant.key, variant.key.length.toUInt())
-
-                val content = mkBvConcatExpr(prefix, restValue)
-
-                val value = state.allocSliceFromData(content)
-                val length = mkSizeExpr(TvmContext.stdMsgAddrSize)
-
-                when (read) {
-                    is TvmCellDataBitArrayRead -> UExprReadResult(value).uncheckedCast<Any, ReadResult>()
-                    is TvmCellDataMsgAddrRead -> UExprPairReadResult(length, value).uncheckedCast()
-                    else -> error("Unexpected read: $read")
-                }
-            }
-
-            is TlbMaybeRefLabel -> {
-                if (read !is TvmCellMaybeConstructorBitRead) {
-                    return@with null
-                }
-
-                val newPath = path.add(curStructure.id)
-
-                val switchStruct =
-                    internalStructure as? SwitchPrefix
-                        ?: error("structure of TlbMaybeRefLabel must be switch")
-
-                val possibleVariants =
-                    state.dataCellInfoStorage.mapper.calculatedTlbLabelInfo.getPossibleSwitchVariants(
-                        switchStruct,
-                        leftTlbDepth,
-                    )
-                val trueVariant = possibleVariants.indexOfFirst { it.key == "1" }
-
-                if (trueVariant == -1) {
-                    return@with UExprReadResult(falseExpr).uncheckedCast<Any, ReadResult>()
-                }
-
-                val expr = generateGuardForSwitch(switchStruct, trueVariant, possibleVariants, state, address, newPath)
-                UExprReadResult(expr).uncheckedCast<Any, ReadResult>()
-            }
-
-            else -> {
-                // TODO
-                null
-            }
-        }
-    }
+): ReadResult? = read.extractTlbValueIfPossible(curStructure, this, address, path, state, leftTlbDepth)
 
 fun extractKBvOfConcreteSizeFromTlbIfPossible(
     curStructure: KnownTypePrefix,
@@ -234,7 +52,7 @@ fun extractKBvOfConcreteSizeFromTlbIfPossible(
         }
     }
 
-private fun extractInt(
+internal fun extractInt(
     offset: UExpr<TvmSizeSort>,
     length: UExpr<TvmSizeSort>,
     data: String,
@@ -248,79 +66,6 @@ private fun extractInt(
                 mkSizeSubExpr(mkSizeExpr(data.length), mkSizeAddExpr(offset, length)).zeroExtendToSort(cellDataSort),
             )
         return extractIntFromShiftedData(shifted, length.zeroExtendToSort(int257sort), isSigned)
-    }
-
-fun <ReadResult : TvmCellDataTypeReadValue> TvmCellDataTypeRead<ReadResult>.readFromConstant(
-    state: TvmState,
-    offset: UExpr<TvmSizeSort>,
-    data: String,
-): ReadResult? =
-    with(offset.ctx.tctx()) {
-        when (this@readFromConstant) {
-            is TvmCellDataIntegerRead -> {
-                val intExpr = extractInt(offset, sizeBits, data, isSigned)
-                UExprReadResult(intExpr).uncheckedCast()
-            }
-
-            is TvmCellMaybeConstructorBitRead -> {
-                val bit = extractInt(offset, oneSizeExpr, data, isSigned = false)
-                val boolExpr =
-                    mkIte(
-                        bit eq zeroValue,
-                        trueBranch = { falseExpr },
-                        falseBranch = { trueExpr },
-                    )
-                UExprReadResult(boolExpr).uncheckedCast()
-            }
-
-            is TvmCellDataMsgAddrRead -> {
-                val concreteOffset = if (offset is KInterpretedValue) offset.intValue() else null
-                val twoDataBits =
-                    if (concreteOffset != null) {
-                        data.substring(concreteOffset, min(concreteOffset + 2, data.length))
-                    } else {
-                        null
-                    }
-                val result =
-                    if (twoDataBits == "00") {
-                        UExprPairReadResult(twoSizeExpr, state.allocSliceFromData(mkBv(0, sizeBits = 2u)))
-                    } else {
-                        null
-                    }
-
-                result?.uncheckedCast<Any, ReadResult>()
-            }
-
-            is TvmCellDataBitArrayRead -> {
-                if (offset is KInterpretedValue) {
-                    val bits =
-                        readConcreteBv(state.ctx, offset.intValue(), data, this@readFromConstant.sizeBits)
-                            ?: return@with null
-                    val slice = state.allocSliceFromData(bits)
-                    UExprReadResult(slice).uncheckedCast()
-                } else {
-                    null
-                }
-            }
-
-            is TvmCellDataCoinsRead -> {
-                val concreteOffset = if (offset is KInterpretedValue) offset.intValue() else null
-                val fourDataBits =
-                    if (concreteOffset != null) {
-                        data.substring(concreteOffset, min(concreteOffset + 4, data.length))
-                    } else {
-                        null
-                    }
-                val result =
-                    if (fourDataBits == "0000") {
-                        UExprPairReadResult(mkBv(0, mkBvSort(4u)), zeroValue)
-                    } else {
-                        null
-                    }
-
-                result?.uncheckedCast<Any, ReadResult>()
-            }
-        }
     }
 
 fun readConcreteBv(

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
@@ -230,13 +230,7 @@ fun <ReadResult : TvmCellDataTypeReadValue> TlbBuiltinLabel.extractKBvOfConcrete
                 return null
             }
 
-            is TlbIntegerLabelOfConcreteSize -> {
-                val field = ConcreteSizeBlockField(concreteSize, curStructure.id, path)
-                val value = state.memory.readField(address, field, field.getSort(this))
-                value
-            }
-
-            is TlbBitArrayOfConcreteSize -> {
+            is FixedSizeDataLabel -> {
                 val field = ConcreteSizeBlockField(concreteSize, curStructure.id, path)
                 val fieldValue = state.memory.readField(address, field, field.getSort(this))
                 fieldValue

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/TlbValueExtraction.kt
@@ -215,25 +215,17 @@ fun <ReadResult : TvmCellDataTypeReadValue> TlbBuiltinLabel.extractTlbValueIfPos
         }
     }
 
-fun <ReadResult : TvmCellDataTypeReadValue> TlbBuiltinLabel.extractKBvOfConcreteSizeFromTlbIfPossible(
+fun extractKBvOfConcreteSizeFromTlbIfPossible(
     curStructure: KnownTypePrefix,
-    read: TvmCellDataTypeRead<ReadResult>,
     address: UHeapRef,
     path: PersistentList<Int>,
     state: TvmState,
 ): UExpr<KBvSort>? =
     with(state.ctx) {
-        check(curStructure.typeLabel == this@extractKBvOfConcreteSizeFromTlbIfPossible)
-        check(read is TvmCellDataBitArrayRead)
-        when (this@extractKBvOfConcreteSizeFromTlbIfPossible) {
-            is TlbCoinsLabel -> {
-                return null
-            }
-
+        when (curStructure.typeLabel) {
             is FixedSizeDataLabel -> {
-                val field = ConcreteSizeBlockField(concreteSize, curStructure.id, path)
-                val fieldValue = state.memory.readField(address, field, field.getSort(this))
-                fieldValue
+                val field = ConcreteSizeBlockField(curStructure.typeLabel.concreteSize, curStructure.id, path)
+                state.memory.readField(address, field, field.getSort(this))
             }
 
             else -> {

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/ConstTlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/ConstTlbStackFrame.kt
@@ -2,7 +2,6 @@ package org.usvm.machine.types.memory.stack
 
 import io.ksmt.expr.KExpr
 import io.ksmt.expr.KInterpretedValue
-import io.ksmt.utils.uncheckedCast
 import kotlinx.collections.immutable.PersistentList
 import org.ton.TlbStructure
 import org.usvm.UBoolExpr
@@ -19,11 +18,9 @@ import org.usvm.machine.types.TvmCellDataBitArrayRead
 import org.usvm.machine.types.TvmCellDataCoinsRead
 import org.usvm.machine.types.TvmCellDataMsgAddrRead
 import org.usvm.machine.types.TvmCellDataTypeRead
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.TvmReadingOutOfSwitchBounds
 import org.usvm.machine.types.TvmReadingSwitchWithUnexpectedType
 import org.usvm.machine.types.memory.readConcreteBv
-import org.usvm.machine.types.memory.readFromConstant
 import org.usvm.machine.types.memory.stack.TlbStackFrame.GuardedResult
 import org.usvm.mkSizeAddExpr
 import org.usvm.mkSizeExpr
@@ -39,7 +36,7 @@ data class ConstTlbStackFrame(
     override val path: PersistentList<Int>,
     override val leftTlbDepth: Int,
 ) : TlbStackFrame {
-    override fun <ReadResult : TvmCellDataTypeReadValue> step(
+    override fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>> =
@@ -101,7 +98,7 @@ data class ConstTlbStackFrame(
                         ContinueLoadOnNextFrame(
                             LimitedLoadData(
                                 loadData.cellAddress,
-                                TvmCellDataBitArrayRead(mkSizeSubExpr(readSize, leftBits)).uncheckedCast(),
+                                type.createLeftBitsDataLoad(mkSizeSubExpr(readSize, leftBits)),
                             ),
                             concreteBvRead,
                         ),
@@ -127,7 +124,7 @@ data class ConstTlbStackFrame(
             return result
         }
 
-    private fun <ReadResult : TvmCellDataTypeReadValue> TvmContext.extractReadSizeFromType(
+    private fun <ReadResult> TvmContext.extractReadSizeFromType(
         type: TvmCellDataTypeRead<ReadResult>,
         concreteOffset: Int?,
     ): KExpr<TvmSizeSort>? {

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/KnownTypeTlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/KnownTypeTlbStackFrame.kt
@@ -12,9 +12,9 @@ import org.ton.TlbCompositeLabel
 import org.ton.TlbIntegerLabelOfSymbolicSize
 import org.ton.TlbSliceByRefInBuilder
 import org.ton.TlbStructure
-import org.usvm.UExpr
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapRef
+import org.usvm.UExpr
 import org.usvm.api.readField
 import org.usvm.machine.TvmContext
 import org.usvm.machine.TvmSizeSort
@@ -22,8 +22,8 @@ import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.intValue
 import org.usvm.machine.state.TvmState
 import org.usvm.machine.state.TvmStructuralError
-import org.usvm.machine.types.ContinueLoadOnNextFrameData
 import org.usvm.machine.state.slicesAreEqual
+import org.usvm.machine.types.ContinueLoadOnNextFrameData
 import org.usvm.machine.types.TvmCellDataBitArrayRead
 import org.usvm.machine.types.TvmCellDataTypeRead
 import org.usvm.machine.types.TvmCellDataTypeReadValue

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/KnownTypeTlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/KnownTypeTlbStackFrame.kt
@@ -2,7 +2,6 @@ package org.usvm.machine.types.memory.stack
 
 import io.ksmt.expr.KBitVecValue
 import io.ksmt.sort.KBvSort
-import io.ksmt.utils.uncheckedCast
 import kotlinx.collections.immutable.PersistentList
 import org.ton.FixedSizeDataLabel
 import org.ton.TlbAddressByRef
@@ -26,8 +25,6 @@ import org.usvm.machine.state.TvmStructuralError
 import org.usvm.machine.state.slicesAreEqual
 import org.usvm.machine.types.ContinueLoadOnNextFrameData
 import org.usvm.machine.types.TvmCellDataBitArrayRead
-import org.usvm.machine.types.TvmCellDataTypeRead
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.TvmReadingOfUnexpectedType
 import org.usvm.machine.types.accepts
 import org.usvm.machine.types.isEmptyLabel
@@ -46,7 +43,7 @@ data class KnownTypeTlbStackFrame(
     override val path: PersistentList<Int>,
     override val leftTlbDepth: Int,
 ) : TlbStackFrame {
-    override fun <ReadResult : TvmCellDataTypeReadValue> step(
+    override fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>> =
@@ -129,7 +126,7 @@ data class KnownTypeTlbStackFrame(
             result
         }
 
-    private fun <ReadResult : TvmCellDataTypeReadValue> createLoadAcrossFramesAction(
+    private fun <ReadResult> createLoadAcrossFramesAction(
         loadData: LimitedLoadData<ReadResult>,
         leftBits: UExpr<TvmSizeSort>,
         bvValue: UExpr<KBvSort>?,
@@ -139,15 +136,13 @@ data class KnownTypeTlbStackFrame(
         return ContinueLoadOnNextFrame(
             LimitedLoadData(
                 loadData.cellAddress,
-                TvmCellDataBitArrayRead(
-                    leftBits,
-                ).uncheckedCast<TvmCellDataBitArrayRead, TvmCellDataTypeRead<ReadResult>>(),
+                loadData.type.createLeftBitsDataLoad(leftBits),
             ),
             bvValue,
         )
     }
 
-    private fun <ReadResult : TvmCellDataTypeReadValue> createStepError(
+    private fun <ReadResult> createStepError(
         expectedLabel: TlbBuiltinLabel,
         args: List<UExpr<TvmSizeSort>>,
         loadData: LimitedLoadData<ReadResult>,
@@ -163,7 +158,7 @@ data class KnownTypeTlbStackFrame(
             state.stack,
         )
 
-    private fun <ReadResult : TvmCellDataTypeReadValue> TvmContext.createContinueLoadingOnNextFrame(
+    private fun <ReadResult> TvmContext.createContinueLoadingOnNextFrame(
         loadData: LimitedLoadData<ReadResult>,
         typeLabel: TlbBuiltinLabel,
         args: List<UExpr<TvmSizeSort>>,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/StackFrameOfUnknown.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/StackFrameOfUnknown.kt
@@ -8,7 +8,6 @@ import org.usvm.api.readField
 import org.usvm.machine.TvmContext
 import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.state.TvmState
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.memory.UnknownBlockField
 import org.usvm.machine.types.memory.stack.TlbStackFrame.GuardedResult
 
@@ -17,7 +16,7 @@ data object StackFrameOfUnknown : TlbStackFrame {
     override val path = emptyList<Int>()
     override val leftTlbDepth: Int = 0
 
-    override fun <ReadResult : TvmCellDataTypeReadValue> step(
+    override fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>> = listOf(GuardedResult(state.ctx.trueExpr, NextFrame(this), value = null))

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/SwitchTlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/SwitchTlbStackFrame.kt
@@ -10,12 +10,10 @@ import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.state.TvmState
 import org.usvm.machine.state.TvmStructuralError
 import org.usvm.machine.types.SizedCellDataTypeRead
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.TvmCellMaybeConstructorBitRead
 import org.usvm.machine.types.TvmReadingOutOfSwitchBounds
 import org.usvm.machine.types.TvmReadingSwitchWithUnexpectedType
 import org.usvm.machine.types.memory.generateGuardForSwitch
-import org.usvm.machine.types.memory.readFromConstant
 import org.usvm.machine.types.memory.stack.TlbStackFrame.GuardedResult
 import org.usvm.mkSizeExpr
 import org.usvm.mkSizeGtExpr
@@ -32,7 +30,7 @@ data class SwitchTlbStackFrame(
         }
     }
 
-    override fun <ReadResult : TvmCellDataTypeReadValue> step(
+    override fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>> =

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStack.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStack.kt
@@ -13,7 +13,6 @@ import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.state.TvmState
 import org.usvm.machine.state.TvmStructuralError
 import org.usvm.machine.state.allocSliceFromData
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.TvmUnexpectedDataReading
 import org.usvm.machine.types.UExprReadResult
 import org.usvm.machine.types.isEmptyRead
@@ -26,7 +25,7 @@ data class TlbStack(
     val isEmpty: Boolean
         get() = frames.isEmpty()
 
-    fun <ReadResult : TvmCellDataTypeReadValue> step(
+    fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>> =
@@ -215,7 +214,7 @@ data class TlbStack(
         val leftBits: Int,
     )
 
-    data class GuardedResult<ReadResult : TvmCellDataTypeReadValue>(
+    data class GuardedResult<ReadResult>(
         val guard: UBoolExpr,
         val result: StepResult,
         val value: ReadResult?,

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStackFrame.kt
@@ -1,9 +1,11 @@
 package org.usvm.machine.types.memory.stack
 
+import io.ksmt.sort.KBvSort
 import kotlinx.collections.immutable.PersistentList
 import org.ton.TlbStructure
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapRef
+import org.usvm.UExpr
 import org.usvm.machine.TvmContext
 import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.state.TvmState
@@ -92,14 +94,24 @@ data class StepError(
     val error: TvmStructuralError?,
 ) : StackFrameStepResult<Nothing>
 
+/**
+ * Represents that the top frame must be replaced by [frame] parameter.
+ * @param concreteLoaded stores a bitvector that was stored after passing the stack frame
+ */
 data class NextFrame(
     val frame: TlbStackFrame,
+    val concreteLoaded: UExpr<KBvSort>? = null,
 ) : StackFrameStepResult<Nothing>
 
 data object EndOfStackFrame : StackFrameStepResult<Nothing>
 
-data class PassLoadToNextFrame<ReadResult : TvmCellDataTypeReadValue>(
+/**
+ * @param loadData the action that must be applied to the stack that was created after partially the partial loading
+ * that spans across multiple Tlb frames.
+ */
+data class ContinueLoadOnNextFrame<ReadResult : TvmCellDataTypeReadValue>(
     val loadData: LimitedLoadData<ReadResult>,
+    val concreteLoaded: UExpr<KBvSort>? = null,
 ) : StackFrameStepResult<ReadResult>
 
 data class LimitedLoadData<ReadResult : TvmCellDataTypeReadValue>(

--- a/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStackFrame.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/types/memory/stack/TlbStackFrame.kt
@@ -11,7 +11,6 @@ import org.usvm.machine.TvmStepScopeManager
 import org.usvm.machine.state.TvmState
 import org.usvm.machine.state.TvmStructuralError
 import org.usvm.machine.types.TvmCellDataTypeRead
-import org.usvm.machine.types.TvmCellDataTypeReadValue
 import org.usvm.machine.types.TvmDataCellLoadedTypeInfo
 
 fun buildFrameForStructure(
@@ -61,7 +60,7 @@ sealed interface TlbStackFrame {
     val path: List<Int>
     val leftTlbDepth: Int
 
-    fun <ReadResult : TvmCellDataTypeReadValue> step(
+    fun <ReadResult> step(
         state: TvmState,
         loadData: LimitedLoadData<ReadResult>,
     ): List<GuardedResult<ReadResult>>
@@ -81,7 +80,7 @@ sealed interface TlbStackFrame {
         otherCellRef: UConcreteHeapRef,
     ): Pair<UBoolExpr?, Unit?>
 
-    data class GuardedResult<ReadResult : TvmCellDataTypeReadValue>(
+    data class GuardedResult<ReadResult>(
         val guard: UBoolExpr,
         val result: StackFrameStepResult<ReadResult>,
         val value: ReadResult?,
@@ -109,21 +108,20 @@ data object EndOfStackFrame : StackFrameStepResult<Nothing>
  * @param loadData the action that must be applied to the stack that was created after partially the partial loading
  * that spans across multiple Tlb frames.
  */
-data class ContinueLoadOnNextFrame<ReadResult : TvmCellDataTypeReadValue>(
+data class ContinueLoadOnNextFrame<ReadResult>(
     val loadData: LimitedLoadData<ReadResult>,
     val concreteLoaded: UExpr<KBvSort>? = null,
 ) : StackFrameStepResult<ReadResult>
 
-data class LimitedLoadData<ReadResult : TvmCellDataTypeReadValue>(
+data class LimitedLoadData<ReadResult>(
     val cellAddress: UConcreteHeapRef,
     val type: TvmCellDataTypeRead<ReadResult>,
 ) {
     companion object {
-        fun <ReadResult : TvmCellDataTypeReadValue> fromLoadData(
-            loadData: TvmDataCellLoadedTypeInfo.LoadData<ReadResult>,
-        ) = LimitedLoadData(
-            type = loadData.type,
-            cellAddress = loadData.cellAddress,
-        )
+        fun <ReadResult> fromLoadData(loadData: TvmDataCellLoadedTypeInfo.LoadData<ReadResult>) =
+            LimitedLoadData(
+                type = loadData.type,
+                cellAddress = loadData.cellAddress,
+            )
     }
 }

--- a/tsa-core/src/main/kotlin/org/usvm/test/resolver/TvmTestStateResolver.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/test/resolver/TvmTestStateResolver.kt
@@ -486,7 +486,7 @@ class TvmTestStateResolver(
                 refs.add(refCell)
             }
 
-            val knownActions = state.dataCellLoadedTypeInfo.addressToActions[modelRef] ?: persistentListOf()
+            val knownActions = state.dataCellLoadedTypeInfo.referenceToActions[modelRef] ?: persistentListOf()
             val tvmCellValue = TvmTestDataCellValue(data, refs, resolveTypeLoad(knownActions))
 
             tvmCellValue.also { resolvedCache[modelRef.address] = tvmCellValue }

--- a/tsa-core/src/main/kotlin/org/usvm/utils/KsmtUtils.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/utils/KsmtUtils.kt
@@ -26,7 +26,7 @@ import org.usvm.memory.foldHeapRef
 val UExpr<out KBvSort>.intValueOrNull: Int?
     get() = (this as? KBitVecValue<*>)?.bigIntValue()?.toInt()
 
-fun TvmContext.extractAddresses(
+fun TvmContext.flattenReferenceIte(
     ref: UHeapRef,
     extractAllocated: Boolean = false,
     extractStatic: Boolean = true,
@@ -51,6 +51,7 @@ fun TvmContext.extractAddresses(
  * our [ref] is a big ITE with concrete values in its conditions.
  *
  * For example:
+ * ```
  * ite(
  *     key eq concreteKey1,
  *     trueBranch = concreteValue1,
@@ -64,8 +65,9 @@ fun TvmContext.extractAddresses(
  *         )
  *     )
  * )
+ * ```
  *
- * With standard [extractAddresses], we get such guards:
+ * With standard [flattenReferenceIte], we get such guards:
  * - key eq concreteKey1
  * - (key eq concreteKey2) and (key neq concreteKey1)
  * - (key eq concreteKey3) and (key neq concreteKey1) and (key neq concreteKey2)
@@ -75,7 +77,7 @@ fun TvmContext.extractAddresses(
  * - key eq concreteKey2
  * - key eq concreteKey3
  * */
-fun TvmContext.extractAddressesSpecialized(
+fun TvmContext.flattenReferenceIteSpecialized(
     ref: UHeapRef,
     extractAllocated: Boolean = true,
     extractStatic: Boolean = true,
@@ -243,7 +245,7 @@ fun <Sort : USort> TvmContext.splitAndRead(
     ref: UHeapRef,
     read: (UConcreteHeapRef) -> UExpr<Sort>,
 ): UExpr<Sort> {
-    val refs = extractAddresses(ref, extractAllocated = true, extractStatic = true)
+    val refs = flattenReferenceIte(ref, extractAllocated = true, extractStatic = true)
     val values =
         refs.map { (guard, concreteRef) ->
             guard to read(concreteRef)

--- a/tsa-test/src/test/kotlin/org/ton/examples/args/ArgsConstraintsTest.kt
+++ b/tsa-test/src/test/kotlin/org/ton/examples/args/ArgsConstraintsTest.kt
@@ -39,7 +39,11 @@ class ArgsConstraintsTest {
     @Test
     fun testConsistentFlags() {
         val path = getResourcePath<ArgsConstraintsTest>(consistentFlagsPath)
-        val result = funcCompileAndAnalyzeAllMethods(path, tvmOptions = TvmOptions(analyzeBouncedMessaged = true))
+        val result =
+            funcCompileAndAnalyzeAllMethods(
+                path,
+                tvmOptions = TvmOptions(analyzeBouncedMessaged = true, turnOnTLBParsingChecks = false),
+            )
         TvmTestExecutor.executeGeneratedTests(result, path, TsRenderer.ContractType.Func)
     }
 

--- a/tsa-test/src/test/kotlin/org/ton/examples/checkers/CheckersTest.kt
+++ b/tsa-test/src/test/kotlin/org/ton/examples/checkers/CheckersTest.kt
@@ -7,7 +7,11 @@ import org.ton.cell.Cell
 import org.ton.communicationSchemeFromJson
 import org.ton.test.utils.FIFT_STDLIB_RESOURCE
 import org.ton.test.utils.checkInvariants
+import org.ton.test.utils.extractCheckerContractFromResource
+import org.ton.test.utils.extractCommunicationSchemeFromResource
+import org.ton.test.utils.extractFuncContractFromResource
 import org.ton.test.utils.extractResource
+import org.ton.test.utils.getAddressBits
 import org.ton.test.utils.propertiesFound
 import org.usvm.machine.IntercontractOptions
 import org.usvm.machine.TactSourcesDescription
@@ -25,6 +29,7 @@ import org.usvm.test.resolver.TvmSuccessfulExecution
 import org.usvm.test.resolver.TvmSymbolicTest
 import org.usvm.test.resolver.TvmTestInput
 import kotlin.io.path.readText
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -46,6 +51,10 @@ class CheckersTest {
     private val bounceFormatContract = "/args/bounce_format_send.fc"
     private val bounceFormatChecker = "/checkers/bounce_format.fc"
     private val bounceFormatScheme = "/checkers/bounce_format_scheme.json"
+    private val intercontractConsistencySender = "/args/inter-contract-consistency.fc"
+    private val intercontractConsistencyRecepient = "/args/inter-contract-consistency-recepient.fc"
+    private val intercontractConsistencyChecker = "/checkers/inter-contract-consistency-checker.fc"
+    private val intercontractConsistencyScheme = "/checkers/inter-contract-consistency.json"
 
     private object TransactionRollBackTestData {
         const val SENDER = "/checkers/transaction-rollback/sender-checker.fc"
@@ -430,6 +439,7 @@ class CheckersTest {
                 IntercontractOptions(
                     communicationScheme = communicationScheme,
                 ),
+            turnOnTLBParsingChecks = false,
             enableOutMessageAnalysis = true,
             stopOnFirstError = false,
         )
@@ -452,6 +462,7 @@ class CheckersTest {
                 listOf(checkerContract, analyzedContract),
                 startContractId = 0,
                 methodId = TvmContext.RECEIVE_INTERNAL_ID,
+                options = TvmOptions(turnOnTLBParsingChecks = false),
             )
 
         // There is at least one failed execution with exit code 257
@@ -471,6 +482,72 @@ class CheckersTest {
                     result is TvmSuccessfulExecution
                 }
             },
+        )
+    }
+
+    @Ignore("Consistency is not met")
+    @Test
+    fun intercontractConsistencyTest() {
+        val pathSender = extractResource(intercontractConsistencySender)
+        val pathRecepient = extractResource(intercontractConsistencyRecepient)
+        val checkerPath = extractResource(intercontractConsistencyChecker)
+
+        val checkerContract =
+            getFuncContract(
+                checkerPath,
+                FIFT_STDLIB_RESOURCE,
+                isTSAChecker = true,
+            )
+        val analyzedSender = getFuncContract(pathSender, FIFT_STDLIB_RESOURCE)
+        val analyzedRecepient = getFuncContract(pathRecepient, FIFT_STDLIB_RESOURCE)
+
+        val communicationSchemePath = extractResource(intercontractConsistencyScheme)
+        val communicationScheme = communicationSchemeFromJson(communicationSchemePath.readText())
+
+        val options =
+            TvmOptions(
+                intercontractOptions =
+                    IntercontractOptions(
+                        communicationScheme = communicationScheme,
+                    ),
+                enableOutMessageAnalysis = true,
+            )
+
+        val tests =
+            analyzeInterContract(
+                listOf(checkerContract, analyzedSender, analyzedRecepient),
+                startContractId = 0,
+                methodId = TvmContext.RECEIVE_INTERNAL_ID,
+                options = options,
+                concreteContractData =
+                    listOf(
+                        TvmConcreteContractData(),
+                        TvmConcreteContractData(),
+                        TvmConcreteContractData(
+                            addressBits =
+                                getAddressBits(
+                                    "0:fd38d098511c43015e02cd185cfcac3befffa89a2a7f20d65440638a9475b9db",
+                                ),
+                        ),
+                    ),
+            )
+
+        assertTrue { tests.isNotEmpty() }
+
+        checkInvariants(
+            tests,
+            listOf(
+                { test -> (test.result as? TvmMethodFailure)?.exitCode == 257 },
+                { test ->
+                    ((((test.additionalInputs[0] as? TvmTestInput.RecvInternalInput)?.msgBody)?.cell)?.data)
+                        ?.startsWith(
+                            "00000000000000000000000001100100" +
+                                getAddressBits(
+                                    "0:fd38d098511c43015e02cd185cfcac3befffa89a2a7f20d65440638a9475b9db",
+                                ),
+                        ) == true
+                },
+            ),
         )
     }
 }

--- a/tsa-test/src/test/kotlin/org/ton/examples/checkers/CheckersTest.kt
+++ b/tsa-test/src/test/kotlin/org/ton/examples/checkers/CheckersTest.kt
@@ -7,11 +7,7 @@ import org.ton.cell.Cell
 import org.ton.communicationSchemeFromJson
 import org.ton.test.utils.FIFT_STDLIB_RESOURCE
 import org.ton.test.utils.checkInvariants
-import org.ton.test.utils.extractCheckerContractFromResource
-import org.ton.test.utils.extractCommunicationSchemeFromResource
-import org.ton.test.utils.extractFuncContractFromResource
 import org.ton.test.utils.extractResource
-import org.ton.test.utils.getAddressBits
 import org.ton.test.utils.propertiesFound
 import org.usvm.machine.IntercontractOptions
 import org.usvm.machine.TactSourcesDescription
@@ -29,9 +25,9 @@ import org.usvm.test.resolver.TvmSuccessfulExecution
 import org.usvm.test.resolver.TvmSymbolicTest
 import org.usvm.test.resolver.TvmTestInput
 import kotlin.io.path.readText
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class CheckersTest {
     private val internalCallChecker = "/checkers/send_internal.fc"
@@ -51,10 +47,6 @@ class CheckersTest {
     private val bounceFormatContract = "/args/bounce_format_send.fc"
     private val bounceFormatChecker = "/checkers/bounce_format.fc"
     private val bounceFormatScheme = "/checkers/bounce_format_scheme.json"
-    private val intercontractConsistencySender = "/args/inter-contract-consistency.fc"
-    private val intercontractConsistencyRecepient = "/args/inter-contract-consistency-recepient.fc"
-    private val intercontractConsistencyChecker = "/checkers/inter-contract-consistency-checker.fc"
-    private val intercontractConsistencyScheme = "/checkers/inter-contract-consistency.json"
 
     private object TransactionRollBackTestData {
         const val SENDER = "/checkers/transaction-rollback/sender-checker.fc"
@@ -446,15 +438,8 @@ class CheckersTest {
 
     @Test
     fun intBlastOptimizationTest() {
+        val checkerContract = extractCheckerContractFromResource(intBlastOptimizationChecker)
         val pathTactConfig = extractResource(tactConfig)
-        val checkerPath = extractResource(intBlastOptimizationChecker)
-
-        val checkerContract =
-            getFuncContract(
-                checkerPath,
-                FIFT_STDLIB_RESOURCE,
-                isTSAChecker = true,
-            )
         val analyzedContract = getTactContract(TactSourcesDescription(pathTactConfig, "IntOptimization", "GuessGame"))
 
         val tests =
@@ -462,7 +447,7 @@ class CheckersTest {
                 listOf(checkerContract, analyzedContract),
                 startContractId = 0,
                 methodId = TvmContext.RECEIVE_INTERNAL_ID,
-                options = TvmOptions(turnOnTLBParsingChecks = false),
+                options = TvmOptions(turnOnTLBParsingChecks = false, timeout = 120.seconds),
             )
 
         // There is at least one failed execution with exit code 257
@@ -482,72 +467,6 @@ class CheckersTest {
                     result is TvmSuccessfulExecution
                 }
             },
-        )
-    }
-
-    @Ignore("Consistency is not met")
-    @Test
-    fun intercontractConsistencyTest() {
-        val pathSender = extractResource(intercontractConsistencySender)
-        val pathRecepient = extractResource(intercontractConsistencyRecepient)
-        val checkerPath = extractResource(intercontractConsistencyChecker)
-
-        val checkerContract =
-            getFuncContract(
-                checkerPath,
-                FIFT_STDLIB_RESOURCE,
-                isTSAChecker = true,
-            )
-        val analyzedSender = getFuncContract(pathSender, FIFT_STDLIB_RESOURCE)
-        val analyzedRecepient = getFuncContract(pathRecepient, FIFT_STDLIB_RESOURCE)
-
-        val communicationSchemePath = extractResource(intercontractConsistencyScheme)
-        val communicationScheme = communicationSchemeFromJson(communicationSchemePath.readText())
-
-        val options =
-            TvmOptions(
-                intercontractOptions =
-                    IntercontractOptions(
-                        communicationScheme = communicationScheme,
-                    ),
-                enableOutMessageAnalysis = true,
-            )
-
-        val tests =
-            analyzeInterContract(
-                listOf(checkerContract, analyzedSender, analyzedRecepient),
-                startContractId = 0,
-                methodId = TvmContext.RECEIVE_INTERNAL_ID,
-                options = options,
-                concreteContractData =
-                    listOf(
-                        TvmConcreteContractData(),
-                        TvmConcreteContractData(),
-                        TvmConcreteContractData(
-                            addressBits =
-                                getAddressBits(
-                                    "0:fd38d098511c43015e02cd185cfcac3befffa89a2a7f20d65440638a9475b9db",
-                                ),
-                        ),
-                    ),
-            )
-
-        assertTrue { tests.isNotEmpty() }
-
-        checkInvariants(
-            tests,
-            listOf(
-                { test -> (test.result as? TvmMethodFailure)?.exitCode == 257 },
-                { test ->
-                    ((((test.additionalInputs[0] as? TvmTestInput.RecvInternalInput)?.msgBody)?.cell)?.data)
-                        ?.startsWith(
-                            "00000000000000000000000001100100" +
-                                getAddressBits(
-                                    "0:fd38d098511c43015e02cd185cfcac3befffa89a2a7f20d65440638a9475b9db",
-                                ),
-                        ) == true
-                },
-            ),
         )
     }
 }

--- a/tsa-test/src/test/kotlin/org/ton/examples/contracts/ContractsTest.kt
+++ b/tsa-test/src/test/kotlin/org/ton/examples/contracts/ContractsTest.kt
@@ -62,7 +62,12 @@ class ContractsTest {
     @EnabledIfEnvironmentVariable(named = RUN_HARD_TESTS_VAR, matches = RUN_HARD_TESTS_REGEX)
     @Test
     fun testPumpersMaster() {
-        analyzeSpecificMethodBoc(pumpersPath, MethodId.ZERO, enableTestGeneration = true)
+        /**
+         * test generation here is disabled due to a bug connected to test data generations
+         * from cells of dict type.
+         * TODO enable the tests after the issue above is fixed
+         */
+        analyzeSpecificMethodBoc(pumpersPath, MethodId.ZERO, enableTestGeneration = false)
     }
 
     @EnabledIfEnvironmentVariable(named = RUN_HARD_TESTS_VAR, matches = RUN_HARD_TESTS_REGEX)

--- a/tsa-test/src/test/resources/args/send_bounce_true.fc
+++ b/tsa-test/src/test/resources/args/send_bounce_true.fc
@@ -3,7 +3,8 @@
 () recv_internal(int my_balance, int msg_value, cell in_msg_full, slice msg_body) impure {
     
     slice cs = in_msg_full.begin_parse();
-    int flags = cs~load_uint(4);
+    int skipped = cs~load_uint(2);
+    int flags = cs~load_uint(2);
     if (flags & 1) {
         set_data(begin_cell().store_uint(1, 1).end_cell());
         return();

--- a/tsa-test/src/test/resources/cell/CellParse.fif
+++ b/tsa-test/src/test/resources/cell/CellParse.fif
@@ -108,25 +108,25 @@ PROGRAM{
     PLDUX
   }>
   load_slice PROC:<{
-    186933 PUSHINT
+    186933 PUSHINT  // 0b101101101000110101 --- length 18
     NEWC
     18 STU
     ENDC
     CTOS
     1 LDSLICE
     SWAP
-    1 PLDU
+    1 PLDU // 1
     SWAP
     3 LDSLICE
     SWAP
-    3 PLDU
+    3 PLDU // 0b011
     SWAP
     6 LDSLICE
     SWAP
-    6 PLDU
+    6 PLDU // 0b011010
     SWAP
     8 PLDSLICE
-    8 PLDU
+    8 PLDU // 0b00110101
   }>
   load_slicex PROC:<{
     186933 PUSHINT

--- a/tsa-test/src/test/resources/checkers/int_optimization.fc
+++ b/tsa-test/src/test/resources/checkers/int_optimization.fc
@@ -15,29 +15,13 @@
 
     ;; Send the messages
     tsa_send_internal_message(1, -10);
-    tsa_assert(tsa_call_1_0(1, -10) == 1);      ;; Removing these assertions after sending each message, causes
-                                                ;; TSA to find the solution in around 10 minutes. The assertions
-                                                ;; cuts the execution time to around 12 seconds!!
     tsa_send_internal_message(1, -20);
-    tsa_assert(tsa_call_1_0(1, -10) == 2);
-
     tsa_send_internal_message(1, -30);
-    tsa_assert(tsa_call_1_0(1, -10) == 3);
-
     tsa_send_internal_message(1, -40);
-    tsa_assert(tsa_call_1_0(1, -10) == 4);
-
     tsa_send_internal_message(1, -50);
-    tsa_assert(tsa_call_1_0(1, -10) == 5);
-
     tsa_send_internal_message(1, -60);
-    tsa_assert(tsa_call_1_0(1, -10) == 6);
-
     tsa_send_internal_message(1, -70);
-    tsa_assert(tsa_call_1_0(1, -10) == 7);
-
     tsa_send_internal_message(1, -80);
-
     ;; Get the final count
     int final_count = tsa_call_1_0(1, -10);
 


### PR DESCRIPTION
The goal of this pull request is to enable the reads from structured memory that lie across multiple nodes of TLb parse tree (currently this is kind of supported of bit array reads)