### PR TITLE
Fixed `Gradle` warning

### DIFF
--- a/buildSrc/src/main/kotlin/tsa.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tsa.kotlin-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -33,9 +34,9 @@ tasks {
         options.compilerArgs = options.compilerArgs + "-Xlint:all" + "-Xlint:-options" // + "-Werror"
     }
     withType<KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
-            freeCompilerArgs += listOf("-Xsam-conversions=class", "-Xcontext-receivers")
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+            freeCompilerArgs.addAll(listOf("-Xsam-conversions=class", "-Xcontext-receivers"))
             // For now, we have some compiler warnings about context receivers.
             // When we resolve it, option [allWarningsAsErrors] should be turned on.
 //            allWarningsAsErrors = true


### PR DESCRIPTION
fixed the warning:
```
w: file:///${path}/tsa/buildSrc/src/main/kotlin/tsa.kotlin-conventions.gradle.kts:36:9 'kotlinOptions(KotlinJvmOptionsDeprecated /* = KotlinJvmOptions */.() -> Unit): Unit' is deprecated. Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln
```

It doesn't affect anything, but now there's one less annoying message :)