### PR TITLE
Prototype of getting opcodes from non-terminated states

### DIFF
--- a/tsa-core/src/main/kotlin/org/usvm/machine/TvmAnalyzer.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/TvmAnalyzer.kt
@@ -468,7 +468,7 @@ private fun runAnalysis(
 ): Pair<List<TvmState>, TvmMethodCoverage> {
     val coverageStatistics = TvmCoverageStatistics(contractIdForCoverageStats, contractForCoverageStats.mainMethod)
 
-    val states = analysisRun(coverageStatistics)
+    val states = analysisRun(coverageStatistics).filter { it.isTerminated }
 
     val coverage =
         TvmMethodCoverage(
@@ -502,7 +502,7 @@ fun analyzeInterContract(
     additionalStopStrategy: TvmAdditionalStopStrategy = NoAdditionalStopStrategy,
     interestingExitCodes: Set<Int> = emptySet(),
 ): TvmSymbolicTestSuite {
-    val machine = TvmMachine(tvmOptions = options)
+    val machine = TvmMachine(tvmOptions = options.copy(collectNonTerminatedState = true))
 
     val (states, coverage) =
         machine.use { machine ->
@@ -528,7 +528,7 @@ fun analyzeInterContract(
             }
         }
 
-    return TvmTestResolver.resolveSingleMethod(methodId, states, coverage)
+    return TvmTestResolver.resolveSingleMethod(methodId, states.filter { it.isTerminated }, coverage)
 }
 
 fun analyzeAllMethods(

--- a/tsa-core/src/main/kotlin/org/usvm/machine/TvmMachine.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/TvmMachine.kt
@@ -5,6 +5,7 @@ import org.ton.TvmInputInfo
 import org.ton.bytecode.TsaContractCode
 import org.ton.bytecode.TvmCodeBlock
 import org.usvm.StateCollectionStrategy
+import org.usvm.StateId
 import org.usvm.UMachine
 import org.usvm.UMachineOptions
 import org.usvm.machine.interpreter.TvmInterpreter
@@ -17,6 +18,7 @@ import org.usvm.machine.statistics.getTvmDebugProfileObserver
 import org.usvm.statistics.CompositeUMachineObserver
 import org.usvm.statistics.StepsStatistics
 import org.usvm.statistics.TimeStatistics
+import org.usvm.statistics.UMachineObserver
 import org.usvm.statistics.collectors.AllStatesCollector
 import org.usvm.statistics.collectors.StatesCollector
 import org.usvm.stopstrategies.GroupedStopStrategy
@@ -154,6 +156,28 @@ class TvmMachine(
                     }
                 }
             }
+        val opcodeAtTheEndObserver =
+            object : UMachineObserver<TvmState> {
+                override fun onMachineStopped() {
+                    val nonTerminatedStates = statesCollector.collectedStates.filter { !it.isTerminated }
+                    val result = mutableMapOf<StateId, Set<BigInteger>>()
+                    for (state in nonTerminatedStates) {
+                        val (opcodes, status) =
+                            TvmOpcodeExtractor(32).extractOpcodeFromState(
+                                state.clone(),
+                                isEnd = true,
+                                loadFromStandardInput = false,
+                            )
+                        result.compute(
+                            state.id,
+                            { _, oldValue -> if (oldValue != null) oldValue + opcodes else opcodes },
+                        )
+                        result[state.id] = opcodes
+                    }
+                    super.onMachineStopped()
+                    logger.info { "Opcodes from non-terminated states is: $result" }
+                }
+            }
 
         val observers =
             mutableListOf(
@@ -162,6 +186,7 @@ class TvmMachine(
                 coverageStatistics,
                 timeStatistics,
                 additionalStopStrategy,
+                opcodeAtTheEndObserver,
             )
 
         observers += psContext.observers

--- a/tsa-core/src/main/kotlin/org/usvm/machine/TvmOpcodeExtractor.kt
+++ b/tsa-core/src/main/kotlin/org/usvm/machine/TvmOpcodeExtractor.kt
@@ -4,6 +4,7 @@ import org.ton.bytecode.MethodId
 import org.ton.bytecode.TsaContractCode
 import org.usvm.UExpr
 import org.usvm.forkblacklists.UForkBlackList
+import org.usvm.logger
 import org.usvm.machine.state.TvmState
 import org.usvm.machine.state.TvmTerminated
 import org.usvm.machine.state.input.RecvInternalInput
@@ -86,9 +87,10 @@ class TvmOpcodeExtractor(
         }
     }
 
-    private fun extractOpcodeFromState(
+    fun extractOpcodeFromState(
         state: TvmState,
         isEnd: Boolean,
+        loadFromStandardInput: Boolean = true,
     ): Pair<Set<BigInteger>, Unit?> =
         with(state.ctx) {
             val scope =
@@ -100,15 +102,16 @@ class TvmOpcodeExtractor(
 
             val opcodes = mutableSetOf<BigInteger>()
 
+            val loadOpcodeFunction = if (loadFromStandardInput) ::loadOpcode else ::loadOpcodeFromAdditionalInput
             val status =
-                loadOpcode(scope) { value ->
+                loadOpcodeFunction(scope) { value ->
                     checkSat(value eq randomOpcode.toBv257())
                         ?: run {
                             // get here if [value == random opcode] couldn't be satisfied (maybe due to unknown)
 
                             opcodes += listPossibleOpcodes(this, value)
 
-                            return@loadOpcode null
+                            return@loadOpcodeFunction null
                         }
 
                     if (isEnd) null else Unit
@@ -125,6 +128,38 @@ class TvmOpcodeExtractor(
             val input =
                 initialInput as? RecvInternalInput
                     ?: error("Unexpected input: $initialInput")
+
+            // hack
+            val oldIsExceptional = isExceptional
+            isExceptional = false
+
+            val (_, value) =
+                sliceLoadIntTlbNoForkAndNoRegister(
+                    scope,
+                    input.msgBodySliceMaybeBounced,
+                    sizeBits = opcodeLength,
+                    isSigned = false,
+                ) ?: return@calcOnState null
+
+            scope.onOpcode(value)
+                ?: return@calcOnState null
+
+            scope.calcOnState {
+                isExceptional = oldIsExceptional
+            }
+        }
+
+    private fun loadOpcodeFromAdditionalInput(
+        scope: TvmStepScopeManager,
+        onOpcode: TvmStepScopeManager.(UExpr<TvmContext.TvmInt257Sort>) -> Unit?,
+    ): Unit? =
+        scope.calcOnState {
+            val input =
+                additionalInputs[0] as? RecvInternalInput
+                    ?: run {
+                        logger.warn("Unexpected input: $initialInput")
+                        return@calcOnState null
+                    }
 
             // hack
             val oldIsExceptional = isExceptional


### PR DESCRIPTION
A proposal to add the information about opcodes from non-terminating states.
The proposed way is to print it to logs and then parse logs.

It is ugly-ish as both the proposed way to extract this information and  the proposed way to return the said information look hacky, but I couldn't find a better solution (yet)